### PR TITLE
Potential fix for code scanning alert no. 2: Query built by concatenation with a possibly-untrusted string

### DIFF
--- a/app/src/main/java/workshop05code/SQLiteConnectionManager.java
+++ b/app/src/main/java/workshop05code/SQLiteConnectionManager.java
@@ -145,11 +145,11 @@ public class SQLiteConnectionManager {
      * @return true if guess exists in the database, false otherwise
      */
     public boolean isValidWord(String guess) {
-        String sql = "SELECT count(id) as total FROM validWords WHERE word like'" + guess + "';";
+        String sql = "SELECT count(id) as total FROM validWords WHERE word like ?;";
 
         try (Connection conn = DriverManager.getConnection(databaseURL);
                 PreparedStatement stmt = conn.prepareStatement(sql)) {
-
+            stmt.setString(1, guess);
             ResultSet resultRows = stmt.executeQuery();
             if (resultRows.next()) {
                 int result = resultRows.getInt("total");


### PR DESCRIPTION
Potential fix for [https://github.com/MQ-COMP3310/w05sqlinjectionpub-jackmoore7/security/code-scanning/2](https://github.com/MQ-COMP3310/w05sqlinjectionpub-jackmoore7/security/code-scanning/2)

To fix the problem, we should use a prepared statement with parameterized queries instead of concatenating the `guess` string directly into the SQL query. This approach ensures that the input is treated as a parameter and not as part of the SQL command, thus preventing SQL injection attacks.

- Replace the concatenated SQL query with a parameterized query using a `?` placeholder for the `guess` parameter.
- Use the `setString` method to safely set the value of the `guess` parameter in the prepared statement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
