### PR TITLE
Potential fix for code scanning alert no. 1: Query built by concatenation with a possibly-untrusted string

### DIFF
--- a/app/src/main/java/workshop05code/SQLiteConnectionManager.java
+++ b/app/src/main/java/workshop05code/SQLiteConnectionManager.java
@@ -127,10 +127,12 @@ public class SQLiteConnectionManager {
      */
     public void addValidWord(int id, String word) {
 
-        String sql = "INSERT INTO validWords(id,word) VALUES('" + id + "','" + word + "')";
+        String sql = "INSERT INTO validWords(id,word) VALUES(?, ?)";
 
         try (Connection conn = DriverManager.getConnection(databaseURL);
                 PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, id);
+            pstmt.setString(2, word);
             pstmt.executeUpdate();
         } catch (SQLException e) {
             System.out.println(e.getMessage());
@@ -145,11 +147,11 @@ public class SQLiteConnectionManager {
      * @return true if guess exists in the database, false otherwise
      */
     public boolean isValidWord(String guess) {
-        String sql = "SELECT count(id) as total FROM validWords WHERE word like'" + guess + "';";
+        String sql = "SELECT count(id) as total FROM validWords WHERE word like ?";
 
         try (Connection conn = DriverManager.getConnection(databaseURL);
                 PreparedStatement stmt = conn.prepareStatement(sql)) {
-
+            stmt.setString(1, guess);
             ResultSet resultRows = stmt.executeQuery();
             if (resultRows.next()) {
                 int result = resultRows.getInt("total");


### PR DESCRIPTION
Potential fix for [https://github.com/MQ-COMP3310/w05sqlinjectionpub-jackmoore7/security/code-scanning/1](https://github.com/MQ-COMP3310/w05sqlinjectionpub-jackmoore7/security/code-scanning/1)

To fix the problem, we should use prepared statements with parameter placeholders instead of concatenating user input directly into the SQL query strings. This approach ensures that user input is treated as data rather than executable code, thus preventing SQL injection attacks.

1. Replace the concatenated SQL query strings with parameterized queries using placeholders (`?`).
2. Use the `setInt` and `setString` methods of `PreparedStatement` to safely insert the user-provided values into the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
